### PR TITLE
Add unified patient modal

### DIFF
--- a/chart.html
+++ b/chart.html
@@ -1225,7 +1225,7 @@
       </div>
 
       <div class="quick-actions">
-        <button class="quick-btn" onclick="showPatientModal()">
+        <button class="quick-btn" onclick="openPatientModal(bedId)">
           <div class="quick-btn-icon">👤</div>
           <div class="quick-btn-text">ข้อมูลผู้ป่วย</div>
         </button>
@@ -1266,40 +1266,7 @@
     </div>
   </div>
 
-  <!-- Patient Modal -->
-  <div class="modal" id="patientModal">
-    <div class="modal-content">
-      <div class="modal-title">👤 ข้อมูลผู้ป่วย</div>
-      <div class="input-group">
-        <label>รหัสผู้ป่วย:</label>
-        <input type="text" id="modalPatientId" placeholder="P001234">
-      </div>
-      <div class="input-group">
-        <label>ยา/สารน้ำ:</label>
-```text
 
-        <select id="modalMedication">
-          <option value="Normal Saline">Normal Saline (0.9% NSS)</option>
-          <option value="Dextrose 5%">Dextrose 5% in Water</option>
-          <option value="Lactated Ringer's">Lactated Ringer's Solution</option>
-          <option value="Dextrose 5% in NSS">D5NSS</option>
-          <option value="Half Normal Saline">0.45% NSS</option>
-        </select>
-      </div>
-      <div class="input-row">
-        <div class="input-group">
-          <label>ปริมาณ (mL):</label>
-          <input type="number" id="modalVolume" placeholder="500">
-        </div>
-        <div class="input-group">
-          <label>อัตรา (ดรอป/นาที):</label>
-          <input type="number" id="modalRate" placeholder="20">
-        </div>
-      </div>
-      <button class="btn btn-success" onclick="savePatientData()">💾 บันทึก</button>
-      <button class="btn btn-secondary" onclick="closeModal('patientModal')">ยกเลิก</button>
-    </div>
-  </div>
 
   <!-- I/O Modal -->
   <div class="modal" id="ioModal">
@@ -1972,14 +1939,7 @@
     }
 
     function showPatientModal() {
-      const patientData = JSON.parse(localStorage.getItem(`ir_data_bed_${bedId}`) || 'null');
-      if (patientData) {
-        document.getElementById('modalPatientId').value = patientData.patient_id;
-        document.getElementById('modalMedication').value = patientData.medication;
-        document.getElementById('modalVolume').value = parseInt(patientData.volume);
-        document.getElementById('modalRate').value = patientData.rate;
-      }
-      document.getElementById('patientModal').style.display = 'flex';
+      openPatientModal(bedId);
     }
 
     function showIOModal() {
@@ -2022,41 +1982,6 @@
       });
     }
 
-    function savePatientData() {
-      const patientId = document.getElementById('modalPatientId').value.trim();
-      const medication = document.getElementById('modalMedication').value;
-      const volume = document.getElementById('modalVolume').value;
-      const rate = document.getElementById('modalRate').value;
-
-      if (!patientId || !volume || !rate) {
-        alert('กรุณากรอกข้อมูลให้ครบถ้วน');
-        return;
-      }
-
-      const patientData = {
-        patient_id: patientId,
-        medication: medication,
-        volume: volume + 'mL',
-        rate: parseInt(rate),
-        timestamp: new Date().toISOString()
-      };
-
-      localStorage.setItem(`ir_data_bed_${bedId}`, JSON.stringify(patientData));
-
-      const notes = JSON.parse(localStorage.getItem(`nurseNotes_${bedId}`) || '[]');
-      notes.unshift({
-        content: `อัพเดทข้อมูลผู้ป่วย: ${patientId} | ${medication} ${volume}mL @ ${rate} ดรอป/นาที`,
-        time: new Date().toLocaleString('th-TH'),
-        author: currentUser.fullname,
-        type: 'medication'
-      });
-      localStorage.setItem(`nurseNotes_${bedId}`, JSON.stringify(notes));
-
-      closeModal('patientModal');
-      alert('✅ บันทึกข้อมูลและคำนวณน้ำเกลือเรียบร้อย');
-      loadPatientData(); // This will auto-populate and calculate IV
-      loadNotes();
-    }
 
     function saveVitalSigns() {
       const systolic = document.getElementById('systolic').value;
@@ -3132,6 +3057,14 @@
       alert('บันทึกผลการคำนวณเรียบร้อย');
     }
 
+  </script>
+
+  <script src="patient-modal.js"></script>
+  <script>
+    window.addEventListener('patientSaved', e => {
+      loadPatientData();
+      loadNotes();
+    });
   </script>
 </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -2955,8 +2955,7 @@
     }
 
     function showQuickAdd() {
-      setupBedSelectors();
-      document.getElementById('quickAddModal').style.display = 'flex';
+      openPatientModal();
     }
 
     function showIOEntry() {
@@ -5001,7 +5000,7 @@ Vital Signs: ${summary.totalVitals} รายการ
           </h3>
           
           <div style="display: grid; gap: 15px;">
-            <button class="btn btn-primary" onclick="showQuickAdd(); this.closest('.modal').remove();">
+            <button class="btn btn-primary" onclick="openPatientModal(); this.closest('.modal').remove();">
               🏥 เพิ่มผู้ป่วยใหม่
             </button>
             
@@ -6070,6 +6069,17 @@ Vital Signs: ${summary.totalVitals} รายการ
     });
 
     
+  </script>
+
+  <script src="patient-modal.js"></script>
+  <script>
+    window.addEventListener('patientSaved', e => {
+      loadBedsData();
+      updateSummary();
+      setTimeout(() => {
+        window.location.href = `chart.html?bed=${e.detail.bedId}`;
+      }, 500);
+    });
   </script>
 
   <!-- Floating Alert Container -->

--- a/patient-modal.js
+++ b/patient-modal.js
@@ -1,0 +1,123 @@
+// Global patient modal for dashboard and chart pages
+(function(){
+  if (typeof document === 'undefined') return;
+
+  // create modal HTML if not present
+  if (!document.getElementById('globalPatientModal')) {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <div class="modal" id="globalPatientModal">
+        <div class="modal-content">
+          <div class="modal-title">👤 ข้อมูลผู้ป่วย</div>
+          <div class="input-group">
+            <label>เตียงที่:</label>
+            <select id="globalBedSelect"></select>
+          </div>
+          <div class="input-group">
+            <label>รหัสผู้ป่วย:</label>
+            <input type="text" id="globalPatientId" placeholder="P001234">
+          </div>
+          <div class="input-group">
+            <label>ยา/สารน้ำ:</label>
+            <select id="globalMedication">
+              <option value="Normal Saline">Normal Saline (0.9% NSS)</option>
+              <option value="Dextrose 5%">Dextrose 5% in Water</option>
+              <option value="Lactated Ringer's">Lactated Ringer's Solution</option>
+              <option value="Dextrose 5% in NSS">D5NSS</option>
+              <option value="Half Normal Saline">0.45% NSS</option>
+            </select>
+          </div>
+          <div class="input-row">
+            <div class="input-group">
+              <label>ปริมาณ (mL):</label>
+              <input type="number" id="globalVolume" placeholder="500">
+            </div>
+            <div class="input-group">
+              <label>อัตรา (ดรอป/นาที):</label>
+              <input type="number" id="globalRate" placeholder="20">
+            </div>
+          </div>
+          <button class="btn btn-primary" id="globalPatientSave">💾 บันทึก</button>
+          <button class="btn btn-secondary" id="globalPatientCancel">ยกเลิก</button>
+        </div>
+      </div>`;
+    document.body.appendChild(div.firstElementChild);
+  }
+
+  const modal = document.getElementById('globalPatientModal');
+  const bedSelect = modal.querySelector('#globalBedSelect');
+  const patientIdInput = modal.querySelector('#globalPatientId');
+  const medSelect = modal.querySelector('#globalMedication');
+  const volumeInput = modal.querySelector('#globalVolume');
+  const rateInput = modal.querySelector('#globalRate');
+
+  // populate bed list
+  function populateBeds() {
+    if (!bedSelect.options.length) {
+      for (let i = 1; i <= 8; i++) {
+        const opt = document.createElement('option');
+        opt.value = i;
+        opt.textContent = `เตียง ${i}`;
+        bedSelect.appendChild(opt);
+      }
+    }
+  }
+
+  // show modal, optionally lock bed
+  window.openPatientModal = function(bedId) {
+    populateBeds();
+    if (bedId) {
+      bedSelect.value = bedId;
+      bedSelect.disabled = true;
+    } else {
+      bedSelect.disabled = false;
+      bedSelect.value = '';
+    }
+
+    const data = dataManager.getPatient(bedId);
+    if (data) {
+      patientIdInput.value = data.patient_id || '';
+      medSelect.value = data.medication || 'Normal Saline';
+      volumeInput.value = parseInt(data.volume) || '';
+      rateInput.value = data.rate || '';
+    } else {
+      patientIdInput.value = '';
+      medSelect.selectedIndex = 0;
+      volumeInput.value = '';
+      rateInput.value = '';
+    }
+
+    modal.style.display = 'flex';
+  };
+
+  function closeModal() {
+    modal.style.display = 'none';
+  }
+
+  modal.querySelector('#globalPatientCancel').addEventListener('click', closeModal);
+
+  modal.querySelector('#globalPatientSave').addEventListener('click', function(){
+    const bedId = bedSelect.value;
+    const patientId = patientIdInput.value.trim();
+    const medication = medSelect.value;
+    const volume = volumeInput.value;
+    const rate = rateInput.value;
+
+    if (!bedId || !patientId || !volume || !rate) {
+      alert('กรุณากรอกข้อมูลให้ครบถ้วน');
+      return;
+    }
+
+    const data = {
+      patient_id: patientId,
+      medication: medication,
+      volume: volume + 'mL',
+      rate: parseInt(rate)
+    };
+
+    const saved = dataManager.savePatient(bedId, data);
+    window.dispatchEvent(new CustomEvent('patientSaved', {detail:{bedId:bedId,patient:saved}}));
+    closeModal();
+    alert('✅ บันทึกข้อมูลผู้ป่วยเรียบร้อย');
+  });
+})();


### PR DESCRIPTION
## Summary
- add new `patient-modal.js` with reusable modal logic
- hook up patient modal to dashboard and chart pages
- open the modal via `openPatientModal` and handle `patientSaved` events

## Testing
- `node -c patient-modal.js`

------
https://chatgpt.com/codex/tasks/task_e_68821a8ec3e483209948e89e24fdc172